### PR TITLE
Switch OpenJDK to Temurin

### DIFF
--- a/Casks/skip.rb
+++ b/Casks/skip.rb
@@ -14,7 +14,7 @@ cask "skip" do
   homepage "https://skip.dev"
 
   depends_on formula: "swiftly"
-  depends_on formula: "openjdk"
+  depends_on formula: "temurin"
   depends_on formula: "gradle"
   depends_on cask: "android-platform-tools"
   depends_on cask: "android-commandlinetools"


### PR DESCRIPTION
macOS comes with system wrappers for Java in `/usr/bin/java`, `/usr/bin/javac`, and `/usr/libexec/java_home` which prints out a candidate path for `$JAVA_HOME.`

OpenJDK is keg-only, requiring users to take a manual step to symlink it into /Library/Java/JavaVirtualMachines to get it to integrate.

Temurin is downstream of OpenJDK, and it _does_ symlink itself into /Library/Java/JavaVirtualMachines, saving users a manual step.

Fixes #1

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: <s>I have tested my change locally with `swift test`</s> (this project doesn't contain Swift)
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

