### PR TITLE
Update Homebrew formula to new format and fix deprecation warning

### DIFF
--- a/Casks/swift-android-toolchain@5.10.1.rb
+++ b/Casks/swift-android-toolchain@5.10.1.rb
@@ -14,7 +14,7 @@ cask "swift-android-toolchain@5.10.1" do
   depends_on cask: "android-commandlinetools"
   depends_on cask: "skiptools/skip/skip"
   depends_on cask: "skiptools/skip/swift-host-toolchain@#{version}"
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   postflight do
     folder = "swift-#{version}-RELEASE-android-sdk"

--- a/Casks/swift-android-toolchain@5.10.rb
+++ b/Casks/swift-android-toolchain@5.10.rb
@@ -14,7 +14,7 @@ cask "swift-android-toolchain@5.10" do
   depends_on cask: "android-commandlinetools"
   depends_on cask: "skiptools/skip/skip"
   depends_on cask: "skiptools/skip/swift-host-toolchain@#{version}"
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   postflight do
     folder = "swift-#{version}-RELEASE-android-sdk"

--- a/Casks/swift-android-toolchain@6.0.1.rb
+++ b/Casks/swift-android-toolchain@6.0.1.rb
@@ -14,7 +14,7 @@ cask "swift-android-toolchain@6.0.1" do
   depends_on cask: "android-commandlinetools"
   depends_on cask: "skiptools/skip/skip"
   depends_on cask: "skiptools/skip/swift-host-toolchain@#{version}"
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   postflight do
     folder = "swift-#{version}-RELEASE-android-sdk"

--- a/Casks/swift-android-toolchain@6.0.2.rb
+++ b/Casks/swift-android-toolchain@6.0.2.rb
@@ -14,7 +14,7 @@ cask "swift-android-toolchain@6.0.2" do
 
   depends_on cask: "skiptools/skip/swift-host-toolchain@#{version}"
   depends_on cask: "skiptools/skip/skip"
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   swiftcmd = Pathname.new("~/Library/Developer/Toolchains/swift-#{version}-RELEASE.xctoolchain/usr/bin/swift").expand_path
 

--- a/Casks/swift-android-toolchain@6.0.3.rb
+++ b/Casks/swift-android-toolchain@6.0.3.rb
@@ -14,7 +14,7 @@ cask "swift-android-toolchain@6.0.3" do
 
   depends_on cask: "skiptools/skip/swift-host-toolchain@#{version}"
   depends_on cask: "skiptools/skip/skip"
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   swiftcmd = Pathname.new("~/Library/Developer/Toolchains/swift-#{version}-RELEASE.xctoolchain/usr/bin/swift").expand_path
 

--- a/Casks/swift-android-toolchain@6.0.rb
+++ b/Casks/swift-android-toolchain@6.0.rb
@@ -14,7 +14,7 @@ cask "swift-android-toolchain@6.0" do
 
   depends_on cask: "skiptools/skip/swift-host-toolchain@#{version}"
   depends_on cask: "skiptools/skip/skip"
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   swiftcmd = Pathname.new("~/Library/Developer/Toolchains/swift-#{version}-RELEASE.xctoolchain/usr/bin/swift").expand_path
 

--- a/Casks/swift-android-toolchain@6.1.rb
+++ b/Casks/swift-android-toolchain@6.1.rb
@@ -14,7 +14,7 @@ cask "swift-android-toolchain@6.1" do
 
   depends_on cask: "skiptools/skip/swift-host-toolchain@#{version}"
   depends_on cask: "skiptools/skip/skip"
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   swiftcmd = Pathname.new("~/Library/Developer/Toolchains/swift-#{version}-RELEASE.xctoolchain/usr/bin/swift").expand_path
 

--- a/Casks/swift-android-toolchain@6.2.0.rb
+++ b/Casks/swift-android-toolchain@6.2.0.rb
@@ -21,7 +21,7 @@ cask "swift-android-toolchain@6.2.0" do
   depends_on cask: "skiptools/skip/swift-host-toolchain@#{version}"
   depends_on cask: "skiptools/skip/skip"
   depends_on cask: "android-ndk"
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   swiftcmd = Pathname.new("~/Library/Developer/Toolchains/swift-#{swift_version_id}.xctoolchain/usr/bin/swift").expand_path
   sdkpath = Pathname.new("~/Library/org.swift.swiftpm/swift-sdks/#{artifact}").expand_path

--- a/Casks/swift-android-toolchain@6.2.3.rb
+++ b/Casks/swift-android-toolchain@6.2.3.rb
@@ -21,7 +21,7 @@ cask "swift-android-toolchain@6.2.3" do
   depends_on cask: "skiptools/skip/swift-host-toolchain@#{version}"
   depends_on cask: "skiptools/skip/skip"
   depends_on cask: "android-ndk"
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   swiftcmd = Pathname.new("~/Library/Developer/Toolchains/swift-#{swift_version_id}.xctoolchain/usr/bin/swift").expand_path
   sdkpath = Pathname.new("~/Library/org.swift.swiftpm/swift-sdks/#{artifact}").expand_path

--- a/Casks/swift-android-toolchain@6.2.rb
+++ b/Casks/swift-android-toolchain@6.2.rb
@@ -21,7 +21,7 @@ cask "swift-android-toolchain@6.2" do
   depends_on cask: "skiptools/skip/swift-host-toolchain@#{version}"
   depends_on cask: "skiptools/skip/skip"
   depends_on cask: "android-ndk"
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   swiftcmd = Pathname.new("~/Library/Developer/Toolchains/swift-#{swift_version_id}.xctoolchain/usr/bin/swift").expand_path
   sdkpath = Pathname.new("~/Library/org.swift.swiftpm/swift-sdks/#{artifact}").expand_path

--- a/Casks/swift-android-toolchain@nightly-6.2.rb
+++ b/Casks/swift-android-toolchain@nightly-6.2.rb
@@ -20,7 +20,7 @@ cask "swift-android-toolchain@nightly-6.2" do
   depends_on cask: "skiptools/skip/swift-host-toolchain@#{version}"
   depends_on cask: "skiptools/skip/skip"
   depends_on cask: "android-ndk"
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   swiftcmd = Pathname.new("~/Library/Developer/Toolchains/swift-#{swift_version}.xctoolchain/usr/bin/swift").expand_path
   sdkpath = Pathname.new("~/Library/org.swift.swiftpm/swift-sdks/#{artifact}").expand_path

--- a/Casks/swift-host-toolchain@5.10.1.rb
+++ b/Casks/swift-host-toolchain@5.10.1.rb
@@ -13,7 +13,7 @@ cask "swift-host-toolchain@5.10.1" do
   #  strategy ""
   #end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   # this tries to install for all users by default, which requires sudo
   #pkg "swift-#{version}-RELEASE-osx.pkg"

--- a/Casks/swift-host-toolchain@5.10.rb
+++ b/Casks/swift-host-toolchain@5.10.rb
@@ -13,7 +13,7 @@ cask "swift-host-toolchain@5.10" do
   #  strategy ""
   #end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   # this tries to install for all users by default, which requires sudo
   #pkg "swift-#{version}-RELEASE-osx.pkg"

--- a/Casks/swift-host-toolchain@6.0.1.rb
+++ b/Casks/swift-host-toolchain@6.0.1.rb
@@ -13,7 +13,7 @@ cask "swift-host-toolchain@6.0.1" do
   #  strategy ""
   #end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   # this tries to install for all users by default, which requires sudo
   #pkg "swift-#{version}-RELEASE-osx.pkg"

--- a/Casks/swift-host-toolchain@6.0.2.rb
+++ b/Casks/swift-host-toolchain@6.0.2.rb
@@ -13,7 +13,7 @@ cask "swift-host-toolchain@6.0.2" do
   #  strategy ""
   #end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   # this tries to install for all users by default, which requires sudo
   #pkg "swift-#{version}-RELEASE-osx.pkg"

--- a/Casks/swift-host-toolchain@6.0.3.rb
+++ b/Casks/swift-host-toolchain@6.0.3.rb
@@ -13,7 +13,7 @@ cask "swift-host-toolchain@6.0.3" do
   #  strategy ""
   #end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   # this tries to install for all users by default, which requires sudo
   #pkg "swift-#{version}-RELEASE-osx.pkg"

--- a/Casks/swift-host-toolchain@6.1.rb
+++ b/Casks/swift-host-toolchain@6.1.rb
@@ -13,7 +13,7 @@ cask "swift-host-toolchain@6.1" do
   #  strategy ""
   #end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   # this tries to install for all users by default, which requires sudo
   #pkg "swift-#{version}-RELEASE-osx.pkg"

--- a/Casks/swift-host-toolchain@6.2.0.rb
+++ b/Casks/swift-host-toolchain@6.2.0.rb
@@ -15,7 +15,7 @@ cask "swift-host-toolchain@6.2.0" do
   #  strategy ""
   #end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   # this tries to install for all users by default, which requires sudo
   #pkg "swift-#{version}-RELEASE-osx.pkg"

--- a/Casks/swift-host-toolchain@6.2.3.rb
+++ b/Casks/swift-host-toolchain@6.2.3.rb
@@ -15,7 +15,7 @@ cask "swift-host-toolchain@6.2.3" do
   #  strategy ""
   #end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   # this tries to install for all users by default, which requires sudo
   #pkg "swift-#{version}-RELEASE-osx.pkg"

--- a/Casks/swift-host-toolchain@6.2.rb
+++ b/Casks/swift-host-toolchain@6.2.rb
@@ -15,7 +15,7 @@ cask "swift-host-toolchain@6.2" do
   #  strategy ""
   #end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   # this tries to install for all users by default, which requires sudo
   #pkg "swift-#{version}-RELEASE-osx.pkg"

--- a/Casks/swift-host-toolchain@nightly-6.2.rb
+++ b/Casks/swift-host-toolchain@nightly-6.2.rb
@@ -16,7 +16,7 @@ cask "swift-host-toolchain@nightly-6.2" do
   #  strategy ""
   #end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   # this tries to install for all users by default, which requires sudo
   #pkg "swift-#{version}-RELEASE-osx.pkg"


### PR DESCRIPTION
fixes the message
'Warning: Calling string comparison format for depends_on macOS: is deprecated!'
I fixed this locally cause the warnings were coming up for a lot of homebrew operations. Using macOS 27 Golden Gate Developer Beta.

- [Y] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [N/A] REQUIRED: I have tested my change locally with `swift test`
- [N/A] OPTIONAL: I have tested my change on an iOS simulator or device
- [N/A] OPTIONAL: I have tested my change on an Android emulator or device
( I signed the Contributor Agreement but I don't think it has been accepted yet 💯 )
-----

- [N] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

